### PR TITLE
JRE-9+ compatibility (update deps)

### DIFF
--- a/bin/crun
+++ b/bin/crun
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-
+set -eux
 export MAVEN_OPTS="-ea"
 mvn -q compile exec:java -Dexec.mainClass="AppKt"

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,10 @@
   <version>1</version>
 
   <properties>
-    <kotlin.version>1.3.72</kotlin.version>
-    <ktor.version>1.3.2</ktor.version>
+    <kotlin.version>1.9.0</kotlin.version>
+    <ktor.version>2.3.3</ktor.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <main.class>AppKt</main.class>
-    <!--    <kotlin.compiler.incremental>true</kotlin.compiler.incremental>-->
   </properties>
 
   <build>
@@ -21,11 +20,10 @@
     <testSourceDirectory>test</testSourceDirectory>
 
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -36,7 +34,6 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-maven-plugin</artifactId>
         <version>${kotlin.version}</version>
-
         <executions>
           <execution>
             <id>compile</id>
@@ -45,7 +42,6 @@
               <goal>compile</goal>
             </goals>
           </execution>
-
           <execution>
             <id>test-compile</id>
             <goals>
@@ -54,12 +50,10 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 
   <dependencies>
-
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>


### PR DESCRIPTION
Particularly org.jetbrains.kotlin version 1.3.72
is not compatible with JRE9+ crashing with
>java.lang.IllegalAccessError: class com.intellij.util.io.FileChannelUtil (in unnamed module @0x6e43ddd6) cannot access class sun.nio.ch.FileChannelImpl (in module java.base) because module java.base does not export sun.nio.ch to unnamed module

before, on JRE "21.0.6" 2025-01-21:
```
hans@LAPTOP-O1AO16UE:~/projects/stonks/ib_api$ time ./bin/crun 
+ export MAVEN_OPTS=-ea
+ MAVEN_OPTS=-ea
+ mvn -q compile exec:java -Dexec.mainClass=AppKt
java.lang.IllegalAccessError: class com.intellij.util.io.FileChannelUtil (in unnamed module @0x6e43ddd6) cannot access class sun.nio.ch.FileChannelImpl (in module java.base) because module java.base does not export sun.nio.ch to unnamed module @0x6e43ddd6
	at com.intellij.util.io.FileChannelUtil.setupUnInterruptibleHandle(FileChannelUtil.java:26)
	at com.intellij.util.io.FileChannelUtil.<clinit>(FileChannelUtil.java:18)
	at com.intellij.util.io.ReadWriteDirectBufferWrapper$FileContext$1.execute(ReadWriteDirectBufferWrapper.java:50)
	at com.intellij.util.io.ReadWriteDirectBufferWrapper$FileContext$1.execute(ReadWriteDirectBufferWrapper.java:42)
	at com.intellij.openapi.util.io.FileUtilRt.doIOOperation(FileUtilRt.java:945)
	at com.intellij.util.io.ReadWriteDirectBufferWrapper$FileContext.<init>(ReadWriteDirectBufferWrapper.java:42)
	at com.intellij.util.io.ReadWriteDirectBufferWrapper.create(ReadWriteDirectBufferWrapper.java:27)
	at com.intellij.util.io.DirectBufferWrapper.getBuffer(DirectBufferWrapper.java:24)
	at com.intellij.util.io.ReadWriteDirectBufferWrapper.getBuffer(ReadWriteDirectBufferWrapper.java:16)
	at com.intellij.util.io.PagedFileStorage$StorageLock.createValue(PagedFileStorage.java:631)
	at com.intellij.util.io.PagedFileStorage$StorageLock.get(PagedFileStorage.java:558)
	at com.intellij.util.io.PagedFileStorage$StorageLock.access$500(PagedFileStorage.java:466)
	at com.intellij.util.io.PagedFileStorage.getBufferWrapper(PagedFileStorage.java:407)
	at com.intellij.util.io.PagedFileStorage.getBuffer(PagedFileStorage.java:371)
	at com.intellij.util.io.PagedFileStorage.putInt(PagedFileStorage.java:144)
	at com.intellij.util.io.ResizeableMappedFile.putInt(ResizeableMappedFile.java:222)
	at com.intellij.util.io.PersistentEnumeratorBase.markDirty(PersistentEnumeratorBase.java:597)
	at com.intellij.util.io.PersistentEnumeratorBase.<init>(PersistentEnumeratorBase.java:185)
	at com.intellij.util.io.PersistentBTreeEnumerator.<init>(PersistentBTreeEnumerator.java:73)
	at com.intellij.util.io.PersistentEnumeratorDelegate.<init>(PersistentEnumeratorDelegate.java:47)
	at com.intellij.util.io.PersistentHashMap.<init>(PersistentHashMap.java:149)
	at com.intellij.util.io.PersistentHashMap.<init>(PersistentHashMap.java:138)
	at com.intellij.util.io.PersistentHashMap.<init>(PersistentHashMap.java:129)
	at com.intellij.util.io.PersistentHashMap.<init>(PersistentHashMap.java:121)
	at com.intellij.util.io.PersistentHashMap.<init>(PersistentHashMap.java:114)
	at org.jetbrains.kotlin.incremental.storage.CachingLazyStorage.createMap(CachingLazyStorage.kt:106)
	at org.jetbrains.kotlin.incremental.storage.CachingLazyStorage.getStorageIfExists(CachingLazyStorage.kt:41)
	at org.jetbrains.kotlin.incremental.storage.CachingLazyStorage.getKeys(CachingLazyStorage.kt:58)
	at org.jetbrains.kotlin.incremental.snapshots.FileSnapshotMap.compareAndUpdate(FileSnapshotMap.kt:35)
	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:83)
	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunnerKt.makeIncrementally(IncrementalJvmCompilerRunner.kt:78)
	at org.jetbrains.kotlin.maven.K2JVMCompileMojo.runIncrementalCompiler(K2JVMCompileMojo.java:270)
	at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execCompiler(K2JVMCompileMojo.java:234)
	at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execCompiler(K2JVMCompileMojo.java:55)
	at org.jetbrains.kotlin.maven.KotlinCompileMojoBase.execute(KotlinCompileMojoBase.java:209)
	at org.jetbrains.kotlin.maven.K2JVMCompileMojo.execute(K2JVMCompileMojo.java:222)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:370)
	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:351)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:215)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:171)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:163)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:298)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:960)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:293)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:196)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:283)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:226)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:407)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:348)
[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.3.72:compile (compile) on project ib_api: Compilation failure -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

real	0m1.724s
user	0m4.284s
sys	0m0.221s
```

after:
```
hans@LAPTOP-O1AO16UE:~/projects/stonks/ib_api$ time ./bin/crun 
+ export MAVEN_OPTS=-ea
+ MAVEN_OPTS=-ea
+ mvn -q compile exec:java -Dexec.mainClass=AppKt
       | Made by http://al6x.com, I do Analytics, Data Mining, Visualisations
  http | started on port 8001
  ib   | will be connected to TWS on port 7496 with 2 parallel connections

```


should fix #3 